### PR TITLE
style: Fix breadcrumbs css to work with non-linked steps

### DIFF
--- a/stylesheets/style/codacy/components/_breadcrumb.scss
+++ b/stylesheets/style/codacy/components/_breadcrumb.scss
@@ -3,7 +3,9 @@
   padding: 0;
 
   > li {
+    color: $gray;
 
+    &, 
     a {
       font-size: $font-sm;
       font-weight: normal;
@@ -37,6 +39,7 @@
 
     &.active {
 
+      &, 
       a {
         font-weight: bold;
       }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23286236/65694412-bc7ee280-e06d-11e9-8a4d-2ed51de4fa70.png)
