### PR TITLE
clean: Remove unnecessary display

### DIFF
--- a/stylesheets/style/codacy/components/_bootstrap-select.scss
+++ b/stylesheets/style/codacy/components/_bootstrap-select.scss
@@ -290,10 +290,6 @@ select.selectpicker {
         span.check-mark {
           display: none;
         }
-
-        span.text {
-          display: inline-block;
-        }
       }
 
       small {


### PR DESCRIPTION
https://codacy.atlassian.net/browse/FT-8264

I searched for other selects in the app and checked if this change would affect nothing. The only select I saw with this class was when we had multiple options and nothing breaks. Really think this is unnecessary.