### PR TITLE
feature: upgrade to FontAwesome5 :breaking:

### DIFF
--- a/stylesheets/style/bootstrap-tagsinput/src/bootstrap-tagsinput.scss
+++ b/stylesheets/style/bootstrap-tagsinput/src/bootstrap-tagsinput.scss
@@ -76,7 +76,8 @@
       &:after {
         font-size: 12px;
         content: "\f00d";
-        font-family: FontAwesome;
+        font-family: $font-family-icon;
+        font-weight: 900;
         padding: 0px 2px;
         color: transparentize($gray-light, 0.5);
       }

--- a/stylesheets/style/codacy/components/_alerts.scss
+++ b/stylesheets/style/codacy/components/_alerts.scss
@@ -92,7 +92,8 @@ a.alert-clickable {
 
       &::after {
         content: "\f00d";
-        font-family: FontAwesome;
+        font-weight: 900;
+        font-family: $font-family-icon;
       }
 
       &:hover {
@@ -123,7 +124,8 @@ a.alert-clickable {
       &:before {
         content: $icon;
         color: $color;
-        font-family: FontAwesome;
+        font-family: $font-family-icon;
+        font-weight: 900;
         margin-right: 5px;
         font-size: $font-lg;
         position: relative;
@@ -173,7 +175,8 @@ $alert-icons: (
     p:first-of-type:before {
       content: $icon;
       color: $color;
-      font-family: FontAwesome;
+      font-family: $font-family-icon;
+      font-weight: 900;
       font-size: $font-lg;
       position: absolute;
       top: 10px;
@@ -209,7 +212,8 @@ $alert-icons: (
   @include box-shadow (0px 1px 6px 1px rgba($brand-neutral-200, 0.8));
 
   &:before {
-    font-family: FontAwesome;
+    font-family: $font-family-icon;
+    font-weight: 900;
     font-size: 17px;
     position: absolute;
     left: 15px;

--- a/stylesheets/style/codacy/components/_bootstrap-select.scss
+++ b/stylesheets/style/codacy/components/_bootstrap-select.scss
@@ -184,7 +184,6 @@ select.selectpicker {
         border: none;
         line-height: 0;
         position: relative;
-        font-weight: normal;
       }
     }
   }
@@ -198,7 +197,7 @@ select.selectpicker {
       .caret {
 
         &:before {
-          content: "\f106";
+          content: "\f077";
         }
       }
     }
@@ -329,7 +328,6 @@ select.selectpicker {
     .caret {
       position: static;
       top: auto;
-      margin-top: -1px;
     }
   }
 

--- a/stylesheets/style/codacy/components/_breadcrumb.scss
+++ b/stylesheets/style/codacy/components/_breadcrumb.scss
@@ -17,7 +17,8 @@
       border-radius: 50%;
       color: $brand-primary;
       content: "\f00c";
-      font-family: FontAwesome;
+      font-family: $font-family-icon;
+      font-weight: 900;
       display: inline-block;
       font-size: 8px;
       height: 12px;
@@ -32,6 +33,8 @@
     //Override bootstrap style
     + li::before {
       content: "\f00c";
+      font-family: $font-family-icon;
+      font-weight: 900;
       color: $brand-primary;
       padding: 0 1px;
       margin-left: 35px;

--- a/stylesheets/style/codacy/components/_dropdowns.scss
+++ b/stylesheets/style/codacy/components/_dropdowns.scss
@@ -24,14 +24,16 @@
   }
 
   &::after {
-    content: " \f107";
-    font-family: FontAwesome;
-    font-weight: normal;
+    content: " \f078";
+    font-family: $font-family-icon;
+    font-weight: 900;
+    font-size: 0.65em;
+    margin-left: 5px;
   }
 
   .open > &.dropdown-toggle {
     &::after {
-      content: " \f106";
+      content: " \f077";
     }
   }
 
@@ -342,8 +344,11 @@
 }
 
 .dropdown-submenu>a:after {
-    content: "\f105";
-    font-family: FontAwesome;
+    content: "\f054";
+    font-size: 0.65em;
+    line-height: 2.2em;
+    font-family: $font-family-icon;
+    font-weight: 900;
     position: absolute;
     right: 8px;
     color: $brand-primary;
@@ -357,7 +362,7 @@
     float: none !important;
 
     >a:after {
-        content: "\f104";
+        content: "\f053";
         left: 8px;
     }
 }
@@ -416,7 +421,8 @@
 
       &:after {
         content: "\f1de";
-        font-family: FontAwesome;
+        font-family: $font-family-icon;
+        font-weight: 900;
         left: 38px;
         position: absolute;
         line-height: 28px;

--- a/stylesheets/style/codacy/components/_forms.scss
+++ b/stylesheets/style/codacy/components/_forms.scss
@@ -294,10 +294,10 @@ input:disabled {
       height: 16px;
       left: 0;
       top: -1px;
-      margin-left: -20px;
+      margin-left: -19px;
       padding-left: 3px;
       padding-top: 0;
-      font-size: 11px;
+      font-size: 9px;
       color: $brand-primary;
     }
   }
@@ -371,9 +371,9 @@ input:disabled {
       &::after {
         width: 18px;
         height: 18px;
-        font-size: $font-md;
+        font-size: $font-normal;
         padding-top: 2px;
-        margin-left: -19px;
+        margin-left: -18px;
       }
     }
   }

--- a/stylesheets/style/codacy/components/_forms.scss
+++ b/stylesheets/style/codacy/components/_forms.scss
@@ -293,7 +293,7 @@ input:disabled {
       width: 16px;
       height: 16px;
       left: 0;
-      top: 0;
+      top: -1px;
       margin-left: -20px;
       padding-left: 3px;
       padding-top: 0;
@@ -317,6 +317,7 @@ input:disabled {
 
     &:checked + label::after {
       font-family: $font-family-icon;
+      font-weight: 900;
       content: $check-icon;
       color: $brand-primary;
     }
@@ -324,7 +325,7 @@ input:disabled {
     &:indeterminate + label::after {
       display: block;
       content: "";
-      width: 10px;
+      width: 9px;
       height: 3px;
       background-color: #555555;
       border-radius: $border-radius-small;
@@ -371,8 +372,8 @@ input:disabled {
         width: 18px;
         height: 18px;
         font-size: $font-md;
-        padding-top: 1px;
-        margin-left: -18px;
+        padding-top: 2px;
+        margin-left: -19px;
       }
     }
   }
@@ -514,6 +515,8 @@ input[type="radio"] {
   &.styled:checked + label::after {
     font-family: $font-family-icon;
     content: $check-icon;
+    font-weight: 900;
+    top: -1px;
   }
   .styled:checked + label {
     &::before {
@@ -553,6 +556,7 @@ label + .switch-md {
       right: 0;
       background-color: $brand-success;
       font-family: $font-family-icon;
+      font-weight: 900;
       content: "\f00c";
       text-align: center;
       line-height: 18px;
@@ -627,6 +631,7 @@ label + .switch-md {
     position: absolute;
     font-family: $font-family-icon;
     font-size: calc(#{$font-normal} - 6px); //8px
+    font-weight: 900;
     content: "\f111";
     color: $brand-danger;
     right: 20px;

--- a/stylesheets/style/codacy/components/_input-groups.scss
+++ b/stylesheets/style/codacy/components/_input-groups.scss
@@ -46,9 +46,9 @@
 
       &::after {
         margin-left: -11px;
-        margin-top: -2px;
+        margin-top: -1px;
         border-radius: 3px 0 0 3px;
-        font-size: $font-lg;
+        font-size: $font-md;
       }
     }
   }

--- a/stylesheets/style/codacy/components/_input-groups.scss
+++ b/stylesheets/style/codacy/components/_input-groups.scss
@@ -45,7 +45,7 @@
       }
 
       &::after {
-        margin-left: -10px;
+        margin-left: -11px;
         margin-top: -2px;
         border-radius: 3px 0 0 3px;
         font-size: $font-lg;

--- a/stylesheets/style/codacy/components/_list.scss
+++ b/stylesheets/style/codacy/components/_list.scss
@@ -13,8 +13,9 @@
 
     &:before {
       @extend .text-success;
-      content: "\f05d";
-      font-family: FontAwesome;
+      content: "\f058";
+      font-weight: 400;
+      font-family: $font-family-icon;
       padding-right: 5px;
     }
 
@@ -23,7 +24,7 @@
 
       &:before {
         color: $brand-neutral-400;
-        content: "\f05c";
+        content: "\f057";
       }
     }
   }

--- a/stylesheets/style/codacy/components/_modals.scss
+++ b/stylesheets/style/codacy/components/_modals.scss
@@ -62,7 +62,8 @@
 
     &:before {
       content: "\f053";
-      font-family: FontAwesome;
+      font-weight: 900;
+      font-family: $font-family-icon;
       position: absolute;
       font-size: $font-sm;
       bottom: 3px;

--- a/stylesheets/style/codacy/components/_navbar.scss
+++ b/stylesheets/style/codacy/components/_navbar.scss
@@ -202,7 +202,8 @@
         //to make caret from select change to a icon of font awesome
         .caret {
           color: $brand-neutral-400;
-          font-family: 'FontAwesome';
+          font-family: $font-family-icon;
+          font-weight: 900;
           position: relative;
           right: 0;
 
@@ -301,7 +302,8 @@
           &::before {
             color: $brand-neutral-500;
             content: "\f002";
-            font-family: "FontAwesome";
+            font-weight: 900;
+            font-family: $font-family-icon;
             font-size: 12px;
             position: absolute;
             top: 12px;

--- a/stylesheets/style/codacy/components/_navs.scss
+++ b/stylesheets/style/codacy/components/_navs.scss
@@ -107,10 +107,11 @@
       }
 
       &::after {
-        content: "\f105";
-        font-family: FontAwesome;
+        content: "\f054";
+        font-size: 0.65em;
+        font-family: $font-family-icon;
+        font-weight: 900;
         font-style: normal;
-        font-weight: normal;
         text-decoration: inherit;
         right: 15px;
         position: absolute;

--- a/stylesheets/style/codacy/components/_panels.scss
+++ b/stylesheets/style/codacy/components/_panels.scss
@@ -98,7 +98,8 @@
         > h5 {
           &:after {
             content: "\f078";
-            font-family: FontAwesome;
+            font-family: $font-family-icon;
+            font-weight: 900;
             float: right;
             color: $brand-neutral-600;
           }
@@ -134,7 +135,8 @@
       font-size: $font-md;
 
       &:before {
-        font-family: FontAwesome;
+        font-family: $font-family-icon;
+        font-weight: 400;
         position: absolute;
         left: 15px;
         font-size: $font-lg;
@@ -145,7 +147,8 @@
 
         &:after {
           content: "\f078";
-          font-family: FontAwesome;
+          font-family: $font-family-icon;
+          font-weight: 900;
           position: absolute;
           right: 30px;
           top: 15px;
@@ -179,7 +182,7 @@
       .panel-heading {
 
         &:before {
-          content: "\f05d";
+          content: "\f058";
           color: $brand-success;
         }
       }
@@ -191,7 +194,7 @@
       .panel-heading {
 
         &:before {
-          content: "\f05c";
+          content: "\f057";
           color: $brand-danger;
         }
       }
@@ -248,7 +251,8 @@ a.panel-clickable {
 
       &:before {
         content: "\f055";
-        font-family: FontAwesome;
+        font-family: $font-family-icon;
+        font-weight: 900;
         margin-right: 5px;
       }
     }

--- a/stylesheets/style/codacy/components/_tables.scss
+++ b/stylesheets/style/codacy/components/_tables.scss
@@ -154,15 +154,19 @@ table {
 
     .table-caret {
       &:after {
-        content: " \f106";
-        font-family: FontAwesome;
+        content: " \f077";
+        font-family: $font-family-icon;
+        font-weight: 900;
+        font-size: 0.65em;
+        margin-left: 2px;
+        vertical-align: 0.1em;
         color: $brand-neutral-500;
       }
 
       &.descending {
 
         &:after {
-          content: " \f107";
+          content: " \f078";
           color: $brand-neutral-500;
         }
       }
@@ -170,7 +174,7 @@ table {
       &.ascending {
 
         &:after {
-          content: " \f106";
+          content: " \f077";
           color: $brand-neutral-500;
         }
       }
@@ -179,12 +183,12 @@ table {
     &:hover {
       .table-caret {
         &:after {
-          content: " \f107";
+          content: " \f078";
         }
 
         &.descending {
           &:after {
-            content: " \f106";
+            content: " \f077";
           }
         }
       }

--- a/stylesheets/style/codacy/essentials/_utils.scss
+++ b/stylesheets/style/codacy/essentials/_utils.scss
@@ -20,15 +20,17 @@ body {
       cursor: pointer;
 
       &::after {
-        content: " \f107";
-        font-family: FontAwesome;
-        font-weight: 400;
+        content: " \f078";
+        font-family: $font-family-icon;
+        font-weight: 900;
+        font-size: 0.65em;
+        margin-left: 5px;
       }
 
       &[aria-expanded="true"] {
         &::after {
-          font-family: FontAwesome;
-          content: " \f106";
+          font-family: $font-family-icon;
+          content: " \f077";
         }
       }
     }
@@ -36,9 +38,9 @@ body {
     //== Add icon indicating the link will open on another tab when there is "target=_blank"
     &[target="_blank"]:not(.no-external-icon) {
       &::after {
-        content: " \f08e";
-        font-family: FontAwesome;
-        font-weight: 400;
+        content: " \f35d";
+        font-weight: 900;
+        font-family: $font-family-icon;
       }
     }
   }
@@ -156,7 +158,8 @@ body {
   &.up {
 
     &:before {
-      font-family: "fontAwesome";
+      font-family: $font-family-icon;
+      font-weight: 900;
       content: "\f106";
     }
   }
@@ -164,7 +167,8 @@ body {
   &.down {
 
     &:before {
-      font-family: "fontAwesome";
+      font-family: $font-family-icon;
+      font-weight: 900;
       content: "\f107";
     }
   }

--- a/stylesheets/style/codacy/essentials/_utils.scss
+++ b/stylesheets/style/codacy/essentials/_utils.scss
@@ -40,6 +40,8 @@ body {
       &::after {
         content: " \f35d";
         font-weight: 900;
+        font-size: .85em;
+        vertical-align: 0.08em;
         font-family: $font-family-icon;
       }
     }

--- a/stylesheets/style/codacy/essentials/_variables.scss
+++ b/stylesheets/style/codacy/essentials/_variables.scss
@@ -56,7 +56,7 @@ $duplication-lighter:    #F1F3FF !default;
 
 /// Typography
 $font-stack:  'Clear-Sans', arial, sans-serif;
-$font-family-icon: 'FontAwesome' !default;
+$font-family-icon: 'Font Awesome 5 Free' !default;
 $btn-font-weight:       bold;
 
 $font-normal: 14px;

--- a/stylesheets/style/codacy/mixins/_icons.scss
+++ b/stylesheets/style/codacy/mixins/_icons.scss
@@ -1,9 +1,10 @@
 @mixin caret() {
-    font-family: 'FontAwesome';
+    font-family: $font-family-icon;
     color: $brand-primary;
-
+    font-weight: 900;
+    font-size: 0.65em;
     &:before {
-      content: "\f107";
+      content: "\f078";
     }
   }
 

--- a/website-legacy/css-guidelines.html
+++ b/website-legacy/css-guidelines.html
@@ -9,7 +9,8 @@
     <title>Codacy styleguide - CSS guidelines</title>
     <!-- Style -->
     <link href="dist/css/template.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/v4-shims.min.css">
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>

--- a/website-legacy/index.html
+++ b/website-legacy/index.html
@@ -31,11 +31,7 @@
         <li class="dropdown">
           <select class="selectpicker" data-width="fit">
             <option selected data-tokens="codacy">Codacy</option>
-            <option data-tokens="codacy2">
-              <span class="text">PedroOrg</span>
-              <span class="fa fa-building"></span>
-              <span class="fa fa-check check-mark"></span>
-            </option>
+            <option data-tokens="codacy2">Codacy2</option>
             <option data-tokens="cenas">Cenas</option>
           </select>
         </li>

--- a/website-legacy/index.html
+++ b/website-legacy/index.html
@@ -8,7 +8,8 @@
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <title>Codacy styleguide</title>
     <!-- Style -->
-    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/v4-shims.min.css">
     <link href="styleguide-code-theme.css" rel="stylesheet">
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
@@ -30,7 +31,11 @@
         <li class="dropdown">
           <select class="selectpicker" data-width="fit">
             <option selected data-tokens="codacy">Codacy</option>
-            <option data-tokens="codacy2">Codacy2</option>
+            <option data-tokens="codacy2">
+              <span class="text">PedroOrg</span>
+              <span class="fa fa-building"></span>
+              <span class="fa fa-check check-mark"></span>
+            </option>
             <option data-tokens="cenas">Cenas</option>
           </select>
         </li>
@@ -708,7 +713,7 @@
                                           <h3>With multiple levels</h3>
                                           <div class="dropdown sg-code">
                                             <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">Tutorials
-                                              <i class="fa fa-angle-down"></i></button>
+                                              <i class="fa fa-chevron-down fa-xs"></i></button>
                                             <ul class="dropdown-menu">
                                               <li><a tabindex="-1" href="#">HTML</a></li>
                                               <li><a tabindex="-1" href="#">CSS</a></li>
@@ -726,7 +731,7 @@
                                           <h3>Opening aligned to the right</h3>
                                           <div class="dropdown pull-left">
                                             <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">Tutorials
-                                              <i class="fa fa-angle-down"></i></button>
+                                              <i class="fa fa-chevron-down fa-xs"></i></button>
                                             <ul class="dropdown-menu dropdown-menu-right">
                                               <li><a tabindex="-1" href="#">HTML</a></li>
                                               <li><a tabindex="-1" href="#">CSS</a></li>
@@ -745,7 +750,7 @@
                                         <h3>Submenu to the left</h3>
                                         <div class="dropdown pull-left">
                                           <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">Tutorials
-                                            <i class="fa fa-angle-down"></i></button>
+                                            <i class="fa fa-chevron-down fa-xs"></i></button>
                                           <ul class="dropdown-menu dropdown-menu-right">
                                             <li><a tabindex="-1" href="#">HTML</a></li>
                                             <li><a tabindex="-1" href="#">CSS</a></li>
@@ -1086,7 +1091,7 @@
                                   <div class="pull-right">
                                     <div class="dropdown">
                                       <button id="qa-dropdown-file-options" class="btn btn-default btn-sm btn-icon dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="true">
-                                        <i class="fa fa-gear" aria-hidden="true"></i> <i class="fa fa-angle-down" aria-hidden="true"></i>
+                                        <i class="fa fa-gear" aria-hidden="true"></i> <i class="fa fa-chevron-down fa-xs" aria-hidden="true"></i>
                                       </button>
                                       <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="qa-dropdown-file-options">
                                         <li><a href="#">Ignore issue</a></li>
@@ -1209,7 +1214,7 @@ return Hex.encodeHexString(result);
                                   <div class="pull-right">
                                     <div class="dropdown">
                                       <button id="qa-dropdown-file-options" class="btn btn-default btn-sm btn-icon dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="true">
-                                        <i class="fa fa-gear" aria-hidden="true"></i> <i class="fa fa-angle-down" aria-hidden="true"></i>
+                                        <i class="fa fa-gear" aria-hidden="true"></i> <i class="fa fa-chevron-down fa-xs" aria-hidden="true"></i>
                                       </button>
                                       <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="qa-dropdown-file-options">
                                         <li><a href="#">Ignore issue</a></li>
@@ -1332,7 +1337,7 @@ return Hex.encodeHexString(result);
                                   <div class="pull-right">
                                     <div class="dropdown">
                                       <button id="qa-dropdown-file-options" class="btn btn-default btn-sm btn-icon dropdown-toggle" data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="true">
-                                        <i class="fa fa-gear" aria-hidden="true"></i> <i class="fa fa-angle-down" aria-hidden="true"></i>
+                                        <i class="fa fa-gear" aria-hidden="true"></i> <i class="fa fa-chevron-down fa-xs" aria-hidden="true"></i>
                                       </button>
                                       <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="qa-dropdown-file-options">
                                         <li><a href="#">Ignore issue</a></li>
@@ -1656,6 +1661,52 @@ return Hex.encodeHexString(result);
                                         </table>
                                     </div>
                                     <!--/.col-->
+                                    <div class="col-md-12">
+                                      <h2>Table with ordered headers</h2>
+                                        <table class="table table-striped table-hover">
+                                          <thead>
+                                            <tr>
+                                              <th class="table-ordered-header js-table-ordered" data-index="1" data-order="ascending" data-url="@call">
+                                                <span id="header1" class="table-caret ascending">header1</span>
+                                              </th>
+                                              <th class="table-ordered-header js-table-ordered" data-index="1" data-order="ascending" data-url="@call">
+                                                <span id="header2" class="table-caret ascending">header2</span>
+                                              </th>
+                                              <th class="table-ordered-header js-table-ordered" data-index="1" data-order="ascending" data-url="@call">
+                                                <span id="header3" class="table-caret ascending">header3</span>
+                                              </th>
+                                            </tr>
+                                          </thead>
+                                          <tbody class="table-body">
+                                            <tr>
+                                              <td class="linked-cell">
+                                                <a href="#">H1Text</a>
+                                              </td>
+                                              <td class="linked-cell">
+                                                <a href="#" >
+                                                  <strong data-toggle="tooltip" data-placement="top" title="@listFile.file.filename">H2Text</strong>
+                                                </a>
+                                              </td>
+                                              <td>
+                                                <a class="table-box secondary" href="#">H3 Text</a>
+                                              </td>
+                                            </tr>
+                                            <tr>
+                                              <td class="linked-cell">
+                                                <a href="#">H1 Text Row 2</a>
+                                              </td>
+                                              <td class="linked-cell">
+                                                <a href="#" >
+                                                  <strong data-toggle="tooltip" data-placement="top" title="@listFile.file.filename">H2Text Row 2</strong>
+                                                </a>
+                                              </td>
+                                              <td>
+                                                <a class="table-box secondary" href="#">H3 Text Row 2</a>
+                                              </td>
+                                            </tr>
+                                          </tbody>
+                                        </table>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2007,7 +2007,7 @@ append-transform@^1.0.0:
   dependencies:
     default-require-extensions "^2.0.0"
 
-aproba@^1.0.3, aproba@^1.1.1:
+aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
@@ -2028,14 +2028,6 @@ archy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
-
-are-we-there-yet@~1.1.2:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
-  integrity sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^2.0.6"
 
 arg@^4.1.0:
   version "4.1.3"
@@ -3583,11 +3575,6 @@ console-browserify@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
   integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
 
-console-control-strings@^1.0.0, console-control-strings@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
-  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
-
 console-stream@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/console-stream/-/console-stream-0.1.1.tgz#a095fe07b20465955f2fafd28b5d72bccd949d44"
@@ -4104,7 +4091,7 @@ debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
+debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -4323,11 +4310,6 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
-delegates@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
-  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -4355,11 +4337,6 @@ detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@2.1.0, detect-newline@^2.1.0:
   version "2.1.0"
@@ -5717,13 +5694,6 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
-
 fs-readdir-recursive@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
@@ -5771,20 +5741,6 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
-
-gauge@~2.7.3:
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
-  integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
-  dependencies:
-    aproba "^1.0.3"
-    console-control-strings "^1.0.0"
-    has-unicode "^2.0.0"
-    object-assign "^4.1.0"
-    signal-exit "^3.0.0"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wide-align "^1.1.0"
 
 gaze@^1.1.0:
   version "1.1.3"
@@ -6379,11 +6335,6 @@ has-to-string-tag-x@^1.2.0:
   dependencies:
     has-symbol-support-x "^1.4.1"
 
-has-unicode@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
-  integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
-
 has-value@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
@@ -6672,7 +6623,7 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -6707,13 +6658,6 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
-
-ignore-walk@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
-  dependencies:
-    minimatch "^3.0.4"
 
 ignore@^3.3.5:
   version "3.3.10"
@@ -8993,20 +8937,13 @@ minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
-minipass@^2.2.0, minipass@^2.3.5, minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
+minipass@^2.2.0, minipass@^2.3.5:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
   integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
   dependencies:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -9145,15 +9082,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.3.2.tgz#3342dea100b7160960a450dc8c22160ac712a528"
-  integrity sha512-DUzITvPVDUy6vczKKYTnWc/pBZ0EnjMJnQ3y+Jo5zfKFimJs7S3HFCxCRZYB9FUZcrzUQr3WsmvZgddMEIZv6w==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -9250,22 +9178,6 @@ node-notifier@^5.4.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.29, node-releases@^1.1.49:
   version "1.1.49"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.49.tgz#67ba5a3fac2319262675ef864ed56798bb33b93e"
@@ -9281,20 +9193,20 @@ nodeunit-x@^0.13.0:
     ejs "^2.5.2"
     tap "^12.6.2"
 
-nopt@^4.0.1, nopt@~4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
-  integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
-
 nopt@~3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   dependencies:
     abbrev "1"
+
+nopt@~4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
+  integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=
+  dependencies:
+    abbrev "1"
+    osenv "^0.1.4"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -9381,13 +9293,6 @@ np@^5.0.3:
     terminal-link "^2.0.0"
     update-notifier "^3.0.0"
 
-npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
-  dependencies:
-    npm-normalize-package-bin "^1.0.1"
-
 npm-conf@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/npm-conf/-/npm-conf-1.1.3.tgz#256cc47bd0e218c259c4e9550bf413bc2192aff9"
@@ -9409,20 +9314,6 @@ npm-name@^5.4.0:
     registry-url "^5.1.0"
     validate-npm-package-name "^3.0.0"
 
-npm-normalize-package-bin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
-  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
-
-npm-packlist@^1.1.6:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
-  integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-    npm-normalize-package-bin "^1.0.1"
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -9443,16 +9334,6 @@ npm-run-path@^4.0.0:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
-
-npmlog@^4.0.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
-  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
-  dependencies:
-    are-we-there-yet "~1.1.2"
-    console-control-strings "~1.1.0"
-    gauge "~2.7.3"
-    set-blocking "~2.0.0"
 
 nth-check@^1.0.2, nth-check@~1.0.1:
   version "1.0.2"
@@ -11257,7 +11138,7 @@ raw-body@~1.1.0:
     bytes "1"
     string_decoder "0.10"
 
-rc@^1.2.7, rc@^1.2.8:
+rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -11583,7 +11464,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-"readable-stream@1 || 2", readable-stream@^2, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -12238,7 +12119,7 @@ serve-static@1.14.1, serve-static@^1.13.2:
     parseurl "~1.3.3"
     send "0.17.1"
 
-set-blocking@^2.0.0, set-blocking@~2.0.0:
+set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -12740,7 +12621,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
+string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -13093,19 +12974,6 @@ tar-stream@^1.5.2:
     readable-stream "^2.3.0"
     to-buffer "^1.1.1"
     xtend "^4.0.0"
-
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
 
 task-graph-runner@^1.0.1:
   version "1.0.3"
@@ -14127,13 +13995,6 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-wide-align@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
-  integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
-  dependencies:
-    string-width "^1.0.2 || 2"
-
 widest-line@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.1.tgz#7438764730ec7ef4381ce4df82fb98a53142a3fc"
@@ -14408,7 +14269,7 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
+yallist@^3.0.0, yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==


### PR DESCRIPTION
Upgraded Font Awesome to version 5.

Small details on the change to take note:
- Font Awesome icons are now by default on `font-weight: 900`, some are not available on 400 because those are the paid 'regular'
- Angle icons (f107, f106, f105, f104) have much more weight on them (bolder), I've replaced these instances by the chevron equivalent. 
- Chevron icons are bigger than angle ones, so I've had to change their font-size and align properly.

What does this affect when merging to the website you might ask?
- [ ] Need to update the CDN link of font-awesome to point to the same v5.
- [ ] Search for the usage of `content: '\f107'` or other angle icons and replace by their chevron counterpart.
- [ ] Search for the usage of `fa-angle-down` or other angle icons, specifically on .btn.dropdown-toggle, and replace for `fa-chevron-down fa-xs`
- [ ] Search for the usage of FontAwesome family, replace by `Font Awesome 5 Free` and place correct font-weight of 900
- [ ] Search for fa icons using -o suffix (ie: fa-lightbulb-o) and replace with alternative icon and/or font-weight ( optional: all of these like lightbulb-o are picked up on the v4-shims, but we shouldn't rely on it )
