### PR TITLE
fix: replace toast icons to use the new ones on react

### DIFF
--- a/stylesheets/style/codacy/components/_alerts.scss
+++ b/stylesheets/style/codacy/components/_alerts.scss
@@ -233,7 +233,7 @@ $alert-icons: (
     border-color: $brand-danger;
 
     &:before {
-      content: "\f05c";
+      content: "\f057";
       color: $brand-danger;
     }
   }
@@ -241,7 +241,7 @@ $alert-icons: (
   &.toast-info {
 
     &:before {
-      content: "\f0eb";
+      content: "\f05a";
       color: $brand-primary;
     }
   }


### PR DESCRIPTION
- Replaced outline error circle on toast for the solid one (same as react)
- Replaced lightbulb icon used for info for the 'i' one (same as react)